### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Add AWS WAF Rate Limiting Protection

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -8,6 +8,27 @@ Creates an [AWS Lambda](https://aws.amazon.com/lambda/) function writing to [Ama
 
 ![architecture](docs/architecture.png)
 
+## AWS WAF Rate Limiting
+
+This API implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** with AWS WAF protection:
+
+**Rate-Based Rule:**
+- Limit: 2,000 requests per 5 minutes per IP address
+- Action: Block requests exceeding the limit
+- Aggregate: Per source IP address
+
+**Benefits:**
+- Protects against DDoS attacks and flooding from specific IPs
+- Blocks malicious traffic at the edge before reaching API Gateway
+- Independent layer of protection from API Gateway throttling
+- CloudWatch metrics and alarms for monitoring blocked requests
+
+**Monitoring:**
+After deployment, monitor WAF metrics in CloudWatch:
+- Namespace: `AWS/WAFV2`
+- Metrics: `BlockedRequests`, `AllowedRequests`
+- Alarm triggers when >100 requests blocked in 5 minutes
+
 ## Setup
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -9,7 +9,10 @@ from aws_cdk import (
     aws_apigateway as apigw_,
     aws_ec2 as ec2,
     aws_iam as iam,
+    aws_wafv2 as wafv2,
+    aws_cloudwatch as cloudwatch,
     Duration,
+    CfnOutput,
 )
 from constructs import Construct
 
@@ -89,11 +92,77 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
         api_hanlder.add_environment("TABLE_NAME", demo_table.table_name)
 
         # Create API Gateway
-        apigw_.LambdaRestApi(
+        api = apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
                 tracing_enabled=True,
             ),
+        )
+
+        # Create WAF Web ACL with rate-based rule
+        web_acl = wafv2.CfnWebACL(
+            self,
+            "ApiWaf",
+            scope="REGIONAL",
+            default_action=wafv2.CfnWebACL.DefaultActionProperty(allow={}),
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="ApiWafMetrics",
+                sampled_requests_enabled=True,
+            ),
+            rules=[
+                wafv2.CfnWebACL.RuleProperty(
+                    name="RateLimitRule",
+                    priority=1,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                            limit=2000,
+                            aggregate_key_type="IP",
+                        )
+                    ),
+                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="RateLimitRule",
+                        sampled_requests_enabled=True,
+                    ),
+                )
+            ],
+        )
+
+        # Associate WAF with API Gateway
+        wafv2.CfnWebACLAssociation(
+            self,
+            "ApiWafAssociation",
+            resource_arn=f"arn:aws:apigateway:{self.region}::/restapis/{api.rest_api_id}/stages/{api.deployment_stage.stage_name}",
+            web_acl_arn=web_acl.attr_arn,
+        )
+
+        # Create CloudWatch alarm for blocked requests
+        cloudwatch.Alarm(
+            self,
+            "WafBlockedRequestsAlarm",
+            metric=cloudwatch.Metric(
+                namespace="AWS/WAFV2",
+                metric_name="BlockedRequests",
+                dimensions_map={
+                    "Rule": "RateLimitRule",
+                    "WebACL": web_acl.name,
+                    "Region": self.region,
+                },
+                statistic="Sum",
+                period=Duration.minutes(5),
+            ),
+            threshold=100,
+            evaluation_periods=1,
+            alarm_description="Alert when WAF blocks more than 100 requests in 5 minutes",
+        )
+
+        CfnOutput(
+            self,
+            "WebAclArn",
+            value=web_acl.attr_arn,
+            description="WAF Web ACL ARN"
         )


### PR DESCRIPTION
## Summary

This PR implements AWS WAF with rate-based rules to protect the API Gateway from DDoS attacks and malicious traffic. The changes address AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** by adding IP-based rate limiting at the edge.

Fixes #5

## Changes Made

### AWS WAF Web ACL with Rate-Based Rule
- Created regional WAF Web ACL for API Gateway protection
- Configured rate-based rule: 2,000 requests per 5 minutes per IP
- Blocks requests exceeding limit with HTTP 403 response
- Enabled CloudWatch metrics and sampled request logging

### WAF Association with API Gateway
- Associated WAF Web ACL with API Gateway deployment stage
- Protection applies to all API endpoints automatically
- Blocks malicious traffic before reaching Lambda

### CloudWatch Monitoring
- Created alarm for blocked requests (threshold: 100 in 5 minutes)
- Enabled WAF metrics: BlockedRequests, AllowedRequests
- Added CloudFormation output for Web ACL ARN

### Documentation Updates
- Added "AWS WAF Rate Limiting" section to README
- Documented rate limit configuration and benefits
- Included monitoring instructions for CloudWatch metrics

## Well-Architected Framework Compliance

These changes implement REL05-BP02 best practice for edge-level protection:

✅ **DDoS Protection**: Rate-based rules block flooding attacks from individual IPs

✅ **Edge-Level Throttling**: Malicious traffic blocked before consuming API Gateway or Lambda resources

✅ **Independent Protection Layer**: WAF operates independently from API Gateway throttling for defense in depth

✅ **Monitoring and Alerting**: CloudWatch alarms notify when rate limiting is triggered

## Testing

After deployment:
1. Verify WAF association: Check API Gateway stage settings in console
2. Test rate limiting: Send >2,000 requests from single IP in 5 minutes
3. Verify blocking: Requests should return HTTP 403 when limit exceeded
4. Monitor CloudWatch: Check `AWS/WAFV2` namespace for BlockedRequests metric
5. Test alarm: Verify alarm triggers when threshold exceeded

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added WAF Web ACL, rate-based rule, association, and CloudWatch alarm
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Added WAF rate limiting documentation